### PR TITLE
tiny change in get_with_length/1 to handle nulls

### DIFF
--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -798,7 +798,11 @@ get_row([Field | OtherFields], Data, Res) ->
 
 get_with_length(Bin) when is_binary(Bin) ->
     {Length, Rest} = get_lcb(Bin),
-    split_binary(Rest, Length).
+    case get_lcb(Bin) of 
+    	 {null, Rest} -> {null, Rest};
+    	 _ -> split_binary(Rest, Length)
+    end.
+
 
 
 get_lcb(<<251:8, Rest/binary>>) ->


### PR DESCRIPTION
Nulls in results (fields) being returned were not being handled - get_row handled null (shows up as undefined) in results, but get_with_length wasn't dealing with a null length before trying to split_binary - comedy resulted. 

So works now. 
