### PR TITLE
Warning on "Reason" var being unused

### DIFF
--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -507,7 +507,7 @@ init([PoolId, Host, Port, User, Password, Database, LogFun, Encoding]) ->
 			    Database, Encoding),
 	    State = #state{log_fun = LogFun1},
 	    {ok, add_conn(Conn, State)};
-	{error, Reason} ->
+	{error, _Reason} ->
 	    ?Log(LogFun1, error,
 		 "failed starting first MySQL connection handler, "
 		 "exiting"),


### PR DESCRIPTION
Rebar won't compile this code because a line throws a warning. Simple fix.
