### PR TITLE
Add encoding comments for Erlang/OTP R17 compatibility

### DIFF
--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -1,3 +1,4 @@
+%%% -*- coding: Latin-1 -*-
 %%% File    : mysql.erl
 %%% Author  : Magnus Ahltorp <ahltorp@nada.kth.se>
 %%% Descrip.: MySQL client.

--- a/src/mysql_auth.erl
+++ b/src/mysql_auth.erl
@@ -1,3 +1,4 @@
+%%% -*- coding: Latin-1 -*-
 %%%-------------------------------------------------------------------
 %%% File    : mysql_auth.erl
 %%% Author  : Fredrik Thulin <ft@it.su.se>

--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -16,7 +16,7 @@
 %%% Modified: 23 Sep 2006 by Yariv Sadan <yarivvv@gmail.com>
 %%% Added transaction handling and prepared statement execution.
 %%%
-%%% Copyright (c) 2001-2004 Kungliga Tekniska Hï¿½gskolan
+%%% Copyright (c) 2001-2004 Kungliga Tekniska Högskolan
 %%% See the file COPYING
 %%%
 %%%

--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -1,3 +1,4 @@
+%%% -*- coding: Latin-1 -*-
 %%%-------------------------------------------------------------------
 %%% File    : mysql_conn.erl
 %%% Author  : Fredrik Thulin <ft@it.su.se>

--- a/src/mysql_recv.erl
+++ b/src/mysql_recv.erl
@@ -1,3 +1,4 @@
+%%% -*- coding: Latin-1 -*-
 %%%-------------------------------------------------------------------
 %%% File    : mysql_recv.erl
 %%% Author  : Fredrik Thulin <ft@it.su.se>


### PR DESCRIPTION
Otherwise the project does not compile with new versions (R17 and up) of Erlang/OTP.
