### PR TITLE
Fix crash on ERROR 1040 (HY000): Too many connections

### DIFF
--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -581,6 +581,11 @@ atom_to_binary(Val) ->
 %%--------------------------------------------------------------------
 mysql_init(Sock, RecvPid, User, Password, LogFun) ->
     case do_recv(LogFun, RecvPid, undefined) of
+	{ok, <<255:8, Rest/binary>>, _InitSeqNum} ->
+	    {Code, ErrData} = get_error_data(Rest, ?MYSQL_4_0),
+	    ?Log2(LogFun, error, "init error ~p: ~p",
+		  [Code, ErrData]),
+	    {error, ErrData};
 	{ok, Packet, InitSeqNum} ->
 	    {Version, Salt1, Salt2, Caps} = greeting(Packet, LogFun),
 	    AuthRes =


### PR DESCRIPTION
If the max_connections are hit (system limit, not user limit),
mysql_conn crashes:

```
1> mysql_conn:start("localhost", 3306, "root", "pwd", "mysql", fun mysql:log/4, utf8, undefined).

=ERROR REPORT==== 25-Aug-2014::21:38:55 ===
Error in process <0.794.0> with exit value: {{badmatch,<<0 bytes>>},[{mysql_conn,greeting,2,[{file,"src/mysql_conn.erl"},{line,626}]},{mysql_conn,mysql_init,5,[{file,"src/mysql_conn.erl"},{line,588}]},{mysql_conn,init,9,[{file,"src/mysql_conn.erl"},{line,325}]}]}

{error,"timed out"}
2>
```

With this fix, the correct error is returned (tested with MySQL 5.5.37):

```
3> mysql_conn:start("localhost", 3306, "root", "pwd", "mysql", fun mysql:log/4, utf8, undefined).
mysql_conn:589: init error 1040: "Too many connections"
{error,login_failed}
mysql_recv:143: mysql_recv: Socket #Port<0.806> closed
4>
```
