### PR TITLE
Fix parsing of floats in scientific notation

### DIFF
--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -943,10 +943,16 @@ convert_type(Val, ColType) ->
 	       T == 'NEWDECIMAL';
 	       T == 'FLOAT';
 	       T == 'DOUBLE' ->
-	    {ok, [Num], _Leftovers} =
+	    {ok, [Num], _Leftovers=[]} =
 		case io_lib:fread("~f", binary_to_list(Val)) of
 		    {error, _} ->
-			io_lib:fread("~d", binary_to_list(Val));
+			case io_lib:fread("~d", binary_to_list(Val)) of
+			    {ok, [_], []} = Res ->
+				Res;
+			    {ok, [X], E} ->
+				F = io_lib:format("~w~s~s" , [X, ".0", E]),
+				io_lib:fread("~f", lists:flatten(F))
+			end;
 		    Res ->
 			Res
 		end,

--- a/test/mysql_test.erl
+++ b/test/mysql_test.erl
@@ -52,11 +52,12 @@ test() ->
     
     mysql:prepare(delete_all, <<"DELETE FROM developer">>),
 
-    {error, foo} = mysql:transaction(
-		     p1,
-		     fun() -> mysql:execute(delete_all),
-			      throw({error, foo})
-		     end),
+    {aborted, {{error, foo}, _}} =
+	mysql:transaction(
+	  p1,
+	  fun() -> mysql:execute(delete_all),
+	           throw({error, foo})
+	  end),
 
     Result4 = mysql:fetch(p1, <<"SELECT * FROM developer">>),
     io:format("Result4: ~p~n", [Result4]),

--- a/test/mysql_test.erl
+++ b/test/mysql_test.erl
@@ -61,6 +61,15 @@ test() ->
 
     Result4 = mysql:fetch(p1, <<"SELECT * FROM developer">>),
     io:format("Result4: ~p~n", [Result4]),
+
+    mysql:fetch(p1, <<"DELETE FROM numbers">>),
+    mysql:prepare(insert_number,
+		  <<"INSERT INTO numbers(name, _double) VALUES (?, ?)">>),
+    D = 1.0e-16,
+    mysql:execute(p1, insert_number, [<<"t1">>, D]),
+    Result5 = mysql:fetch(p1, <<"SELECT * FROM numbers WHERE name='t1'">>),
+    {data, {mysql_result, _, [[<<"t1">>, D]], _, _, _, _, _}} = Result5,
+    mysql:fetch(p1, <<"DELETE FROM numbers">>),
 				    
     ok.
     


### PR DESCRIPTION
MySQL returns e.g. the double 0.0000000000000001 as 1E-16, which cannot be parsed by erlang-mysql-driver. Instead it returns the integer 1.

This patch fixes issue #20 and adds a test case.