### PR TITLE
trigger reconnection when socket broken

### DIFF
--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -17,7 +17,7 @@
 %%% Modified: 23 Sep 2006 by Yariv Sadan <yarivvv@gmail.com>
 %%% Added transaction handling and prepared statement execution.
 %%%
-%%% Copyright (c) 2001-2004 Kungliga Tekniska Högskolan
+%%% Copyright (c) 2001-2004 Kungliga Tekniska HÃ¶gskolan
 %%% See the file COPYING
 %%%
 %%%
@@ -467,6 +467,8 @@ do_query(Sock, RecvPid, LogFun, Query, Version) ->
 	    Msg = io_lib:format("Failed sending data "
 				"on socket : ~p",
 				[Reason]),
+	    gen_tcp:close(Sock),
+            RecvPid ! {tcp_closed, Sock},
 	    {error, Msg}
     end.
 

--- a/src/mysql_conn.erl
+++ b/src/mysql_conn.erl
@@ -467,8 +467,6 @@ do_query(Sock, RecvPid, LogFun, Query, Version) ->
 	    Msg = io_lib:format("Failed sending data "
 				"on socket : ~p",
 				[Reason]),
-	    gen_tcp:close(Sock),
-            RecvPid ! {tcp_closed, Sock},
 	    {error, Msg}
     end.
 

--- a/src/mysql_recv.erl
+++ b/src/mysql_recv.erl
@@ -10,7 +10,7 @@
 %%% Note    : All MySQL code was written by Magnus Ahltorp, originally
 %%%           in the file mysql.erl - I just moved it here.
 %%%
-%%% Copyright (c) 2001-2004 Kungliga Tekniska Högskolan
+%%% Copyright (c) 2001-2004 Kungliga Tekniska HÃ¶gskolan
 %%% See the file COPYING
 %%%
 %%%           Signals this receiver process can send to it's parent
@@ -75,6 +75,7 @@ start_link(Host, Port, LogFun, Parent) when is_list(Host), is_integer(Port) ->
 	spawn_link(fun () ->
 			   init(Host, Port, LogFun, Parent)
 		   end),
+	erlang:monitor(process, RecvPid),
     %% wait for the socket from the spawned pid
     receive
 	{mysql_recv, RecvPid, init, {error, E}} ->


### PR DESCRIPTION
This commit can fix the problem that old codes do not trigger reconnection when socket broken.The new codes can trigger reconnection when socket broken occur.