### PR TITLE
Fix LogFun-related crash on connection error in mysql:init/1.

### DIFF
--- a/src/mysql.erl
+++ b/src/mysql.erl
@@ -539,7 +539,7 @@ init([PoolId, Host, Port, User, Password, Database, LogFun, Encoding]) ->
 		  password = Password,
 		  database = Database,
 		  encoding = Encoding},
-		  start_reconnect(C, LogFun),
+		  start_reconnect(C, LogFun1),
 	    {ok, #state{log_fun = LogFun1}}
     end.
 


### PR DESCRIPTION
In mysql:init/1, if LogFun was 'undefined' and the initial mysql connection failed, mysql:start_reconnect/2 would crash attempting to log the reconnection attempt.